### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Ting
+# Ting
 [![Build Status](https://travis-ci.org/Aufree/ting.svg?branch=master)](https://travis-ci.org/Aufree/ting)
 
 Ting is a music social networking project written in Ruby on Rails and Semantic-UI.
@@ -7,7 +7,7 @@ You can check out the demo at [this link](http://tinger.herokuapp.com).
 
 **You can ping me on [Twitter](https://twitter.com/_Paul_King_) or follow me on [Weibo](http://weibo.com/jinfali).**
 
-##Screen Shots
+## Screen Shots
 
 ![](http://ww1.sinaimg.cn/large/76dc7f1bgw1ent5zzgeyvj21kw11416d.jpg)
 
@@ -19,39 +19,39 @@ You can check out the demo at [this link](http://tinger.herokuapp.com).
 
 ![](http://ww1.sinaimg.cn/large/76dc7f1bgw1ent60ssvxgj21kw1147aa.jpg)
 
-##Requirements
+## Requirements
 
 Ruby 2.0.0 +    
 Memcached 1.4 +    
 ImageMagick 6.8 +    
 
 
-##Installation
+## Installation
 
     $ git clone git://github.com/Aufree/ting.git
     $ cd ting
 
-###Linux(Ubuntu)
+### Linux(Ubuntu)
 
     $ sudo apt-get update
     $ sudo apt-get install memcached imagemagick
 
-###Mac OS
+### Mac OS
 
     $ brew install memcached && brew install imagemagick
 
-##Run
+## Run
 
     $ bundle install
     $ rake db:migrate
     # ensure that memcached has started up
     $ rails s
 
-##Testing
+## Testing
 
     $ rake test
 
-##License
+## License
 
 Copyright (c) 2015 Paul King
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
